### PR TITLE
Fix installation issue in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "@rbxts/ecr": "^0.8.0-ts.0",
-    "@rbxts/gorp": "file:../gorp-ts/rbxts-gorp-0.2.0-ts.0.tgz"
+    "@rbxts/gorp": "^0.2.0-ts.0"
   }
 }


### PR DESCRIPTION
@rbxts/gorp dependency was set to a non existent local directory, changed it to the latest version